### PR TITLE
enable cors on basemaps.utah.gov

### DIFF
--- a/src/app/config.js
+++ b/src/app/config.js
@@ -15,6 +15,7 @@ define([
     // force api to use CORS on mapserv thus removing the test request on app load
     // e.g. http://mapserv.utah.gov/ArcGIS/rest/info?f=json
     esriConfig.defaults.io.corsEnabledServers.push('mapserv.utah.gov');
+    esriConfig.defaults.io.corsEnabledServers.push('basemaps.utah.gov');
 
     var markerSymbolWidth = 24;
     var markerSymbolHeight = 35;


### PR DESCRIPTION
remove jsonp requests like 

`http://basemaps.utah.gov/ArcGIS/rest/services/BaseMaps/Lite/MapServer?f=json&callback=dojo.io.script.jsonp_dojoIoScript1._jsonpCallback`
